### PR TITLE
Bugfix wrong return type solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # PowerDynSolve.jl Changelog
 
+## Verions 0.7
+
+* ![bugfix](https://img.shields.io/badge/PD-bugfix-%23d73a4a.svg) [fixed: calling solution for a single time point and a single node returned an array with a single element instead of the actual element](https://github.com/JuliaEnergy/PowerDynSolve.jl/pull/26)
+
 ## Version 0.6
 
 * ![bugfix](https://img.shields.io/badge/PD-bugfix-%23d73a4a.svg) [calling solve on a grid and state that do not belong to each other now raises an AssertionError](https://github.com/JuliaEnergy/PowerDynSolve.jl/pull/23)

--- a/src/CompositeGridSolution.jl
+++ b/src/CompositeGridSolution.jl
@@ -90,7 +90,6 @@ function insertMissingData(data::AbstractArray{T,2}, n::AbstractArray, removed::
     len = size(data, 1)
     for (i, s) in enumerate(n)
         if s ∈ removed
-            @show s
             data = hcat(data[:,1:i-1], fill(NaN, len), data[:,i:end])
         end
     end

--- a/src/GridSolutions.jl
+++ b/src/GridSolutions.jl
@@ -89,6 +89,7 @@ end
 (sol::GridSolution)(t, n, ::Type{Val{:v}}) = sol(t, n, :u) .|> abs
 (sol::GridSolution)(t, n, ::Type{Val{:φ}}) = sol(t, n, :u) .|> angle
 (sol::GridSolution)(t, n, ::Type{Val{:i}}) = (AdmittanceLaplacian(sol) * sol(t, :, :u))[n, :]
+(sol::GridSolution)(t::Number, n, ::Type{Val{:i}}) = (AdmittanceLaplacian(sol) * sol(t, :, :u))[n]
 (sol::GridSolution)(t, n, ::Type{Val{:iabs}}) = sol(t, n, :i) .|> abs
 (sol::GridSolution)(t, n, ::Type{Val{:δ}}) = sol(t, n, :i) .|> angle
 (sol::GridSolution)(t, n, ::Type{Val{:s}}) = sol(t, n, :u) .* conj.(sol(t, n, :i))

--- a/test/gridsolutions.jl
+++ b/test/gridsolutions.jl
@@ -109,8 +109,13 @@ sol = solve(p)
 @test (range(0, stop=10, length=1_000) .≈ tspan(sol, 1_000)) |> all
 ts = tspan(sol, 10_000)
 for t in [ts, 0.1], n in [1:2, :, 1, 2]
-    for syms=[(:u,), (:p,), (:v,), (:int, 1), (:ω,) ]
-        @test_nowarn sol(t, n, syms...)
+    if n == (:)
+        result_size = (2, size(t)...)
+    else
+        result_size = (size(n)..., size(t)...)
+    end
+    for syms=[(:u,), (:i,), (:p,), (:v,), (:int, 1), (:ω,) ]
+        @test size(sol(t, n, syms...)) == result_size
     end
     @test sol(t, n, :int, 1) == sol(t, n, :ω)
 end


### PR DESCRIPTION
For a GridSolution `sol`, sol(::Number, ::Number, :i)` return an array with a single element instead of just the single element. Fixed that with a small line and added a test